### PR TITLE
Optional Definition Meta attributes

### DIFF
--- a/src/core/CardTemplate.gd
+++ b/src/core/CardTemplate.gd
@@ -534,37 +534,43 @@ func modify_property(property: String, value, is_init = false, check := false) -
 			set_card_name(value)
 		elif not check:
 			properties[property] = value
-			var label_node = _card_labels[property]
-			if not is_init:
-				emit_signal("card_properties_modified",
-						self, "card_properties_modified",
-						{"property_name": property,
-						"new_property_value": value,
-						"previous_property_value": previous_value})
-			# These are int or float properties which need to be converted
-			# to a string with some formatting.
-			#
-			# In this demo, the format is defined as: "labelname: value"
-			if property in CardConfig.PROPERTIES_NUMBERS:
-				_set_label_text(label_node,property
-						+ ": " + str(value))
-			# These are arrays of properties which are put in a label with a simple
-			# Join character
-			elif property in CardConfig.PROPERTIES_ARRAYS:
-				_set_label_text(label_node,
-						CFUtils.array_join(value,
-						CFConst.ARRAY_PROPERTY_JOIN))
-			# These are standard properties which is simple a String to add to the
-			# label.text field
-			# Normally they should be defined in CardConfig.PROPERTIES_STRINGS
-			# but this is also the fallback we use for
-			# properties undefined in CardConfig
+			if not _card_labels.has(property):
+				if not property.begins_with("_"):
+					print_debug("Warning: ", property,
+							" does not have a matching label!")
+				retcode = CFConst.ReturnCode.FAILED
 			else:
-				_set_label_text(label_node, str(value))
-				# If we have an empty property, we let the other labels
-				# use the space vertical space it would have taken.
-			if label_node.text == "" :
-				label_node.visible = false
+				var label_node = _card_labels[property]
+				if not is_init:
+					emit_signal("card_properties_modified",
+							self, "card_properties_modified",
+							{"property_name": property,
+							"new_property_value": value,
+							"previous_property_value": previous_value})
+				# These are int or float properties which need to be converted
+				# to a string with some formatting.
+				#
+				# In this demo, the format is defined as: "labelname: value"
+				if property in CardConfig.PROPERTIES_NUMBERS:
+					_set_label_text(label_node,property
+							+ ": " + str(value))
+				# These are arrays of properties which are put in a label
+				# with a simple join character
+				elif property in CardConfig.PROPERTIES_ARRAYS:
+					_set_label_text(label_node,
+							CFUtils.array_join(value,
+							CFConst.ARRAY_PROPERTY_JOIN))
+				# These are standard properties which is simple a String to add to the
+				# label.text field
+				# Normally they should be defined in CardConfig.PROPERTIES_STRINGS
+				# but this is also the fallback we use for
+				# properties undefined in CardConfig
+				else:
+					_set_label_text(label_node, str(value))
+					# If we have an empty property, we let the other labels
+					# use the space vertical space it would have taken.
+				if label_node.text == "" :
+					label_node.visible = false
 	return(retcode)
 
 

--- a/src/custom/cards/CardConfig.gd
+++ b/src/custom/cards/CardConfig.gd
@@ -1,5 +1,13 @@
 # This class defines how the properties of the [Card] definition are to be
 # used during `setup()`
+#
+# All the properties defined on the card json will attempt to find a matching
+# label node inside the cards _card_labels dictionary.
+# If one was not found, an error will be printed.
+#
+# The exception is properties starting with _underscore. This are considered
+# Meta properties and the game will not attempt to display them on the card
+# front.
 class_name CardConfig
 extends Reference
 
@@ -10,9 +18,6 @@ const PROPERTIES_NUMBERS := ["Cost","Power"]
 # Properties provided in a list which are converted into a string for the
 # label text, using the array_join() method
 const PROPERTIES_ARRAYS := ["Tags"]
-# Properties which are not visible on the card front, but are nevertheless
-# needed for the game in some way.
-const META := ["_template"]
 # This property matches the name of the scene file (without the .tcsn file)
 # which is used as a template For this card.
 const SCENE_PROPERTY = "Type"

--- a/tests/unit/test_card_class.gd
+++ b/tests/unit/test_card_class.gd
@@ -92,7 +92,23 @@ func test_card_name_setget():
 			'Name Label text is set correctly')
 
 func test_CardDefinition_properties():
-	pending("Array property should use the separator")
+	cfc.card_definitions["GUT Card"] = {
+		"Type": "Red",
+		"Tags": ["Tag 1","Tag 2","GUT Tag"],
+		"Requirements": "",
+		"Abilities": "Gut Test",
+		"_meta": "This is a meta property",
+		"_meta2": "They are not displayed on the card",
+		"Cost": 10,
+		"Power": 0,
+	}
+	var new_card = cfc.instance_card("GUT Card")
+	board.add_child(new_card)
+	new_card._determine_idle_state()
+	assert_eq(new_card._card_labels["Tags"].text,"Tag 1 - Tag 2 - GUT Tag",
+			"Array property uses the separator")
+	assert_eq(new_card._card_labels["Cost"].text, "Cost: 10",
+			"Integer properties are converted into strings")
 
 func test_font_size():
 	var text_node = card._card_labels["Abilities"]


### PR DESCRIPTION
Allows for setting attributes in your SetDefinitions without needing a matching label.  For

instance you can create a "Rarity" attribute that tells your deck building function how many cards
to put in a deck.  If you don't have matching label it will spit out a warning but won't crash.  If
you start your attribute with an '_' like "_Rarity" it will surpress this warning.